### PR TITLE
🐛 we lack (package) integrity

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: resideo/actions/publish-previews@v1.3.1
+      - uses: resideo/actions/publish-previews@v1.4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.RESIDEO_BOT_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: resideo/actions/publish-releases@v1.3.1
+      - uses: resideo/actions/publish-releases@v1.4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.RESIDEO_BOT_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@resideo/graphql-voyager",
-  "version": "1.0.0-rc.28.local",
+  "version": "1.0.1-rc.28.local",
   "description": "GraphQL introspection viewer",
   "repository": {
     "type": "git",


### PR DESCRIPTION
For some reason yarn really doesn't like the previously released packages, they fail to install with the following error:
```
❯ yarn add @resideo/graphql-voyager
yarn add v1.21.1
[1/4] 🔍  Resolving packages...
warning @resideo/graphql-voyager > @material-ui/core > recompose > fbjs > core-js@1.2.7: core-js@<3 is no longer maintained and not recommended for usage due to the number of issues. Please, upgrade your dependencies to the actual version of core-js@3.
[2/4] 🚚  Fetching packages...
error https://npm.pkg.github.com/download/@resideo/graphql-voyager/1.0.0/518411321c2b8ee05b6856c51c59655d74f4f75e5ed4163e0f40f7b5c6c1c865: Integrity checked failed for "@resideo/graphql-voyager" (none of the specified algorithms are supported)
info Visit https://yarnpkg.com/en/docs/cli/add for documentation about this command.
```

This is a PR to try and figure out why yarn is complaining about our lack of integrity.